### PR TITLE
add terraform credentials type for backend configuration

### DIFF
--- a/awx/main/models/credential/__init__.py
+++ b/awx/main/models/credential/__init__.py
@@ -1197,6 +1197,26 @@ ManagedCredentialType(
     },
 )
 
+ManagedCredentialType(
+    namespace='terraform',
+    kind='cloud',
+    name=gettext_noop('Terraform backend configuration'),
+    managed=True,
+    inputs={
+        'fields': [
+            {
+                'id': 'configuration',
+                'label': gettext_noop('Backend configuration'),
+                'type': 'string',
+                'secret': True,
+                'multiline': True,
+                'help_text': gettext_noop('Terraform backend config as Hashicorp configuration language.'),
+            },
+        ],
+        'required': ['configuration'],
+    },
+)
+
 
 class CredentialInputSource(PrimordialModel):
     class Meta:

--- a/awx/main/models/credential/injectors.py
+++ b/awx/main/models/credential/injectors.py
@@ -122,3 +122,11 @@ def kubernetes_bearer_token(cred, env, private_data_dir):
         env['K8S_AUTH_SSL_CA_CERT'] = to_container_path(path, private_data_dir)
     else:
         env['K8S_AUTH_VERIFY_SSL'] = 'False'
+
+
+def terraform(cred, env, private_data_dir):
+    handle, path = tempfile.mkstemp(dir=os.path.join(private_data_dir, 'env'))
+    with os.fdopen(handle, 'w') as f:
+        os.chmod(path, stat.S_IRUSR | stat.S_IWUSR)
+        f.write(cred.get_input('configuration'))
+    env['TF_BACKEND_CONFIG_FILE'] = to_container_path(path, private_data_dir)

--- a/awx/main/tests/unit/test_tasks.py
+++ b/awx/main/tests/unit/test_tasks.py
@@ -1092,6 +1092,27 @@ class TestJobCredentials(TestJobExecution):
         assert open(env['ANSIBLE_NET_SSH_KEYFILE'], 'r').read() == self.EXAMPLE_PRIVATE_KEY
         assert safe_env['ANSIBLE_NET_PASSWORD'] == HIDDEN_PASSWORD
 
+    def test_terraform_cloud_credentials(self, job, private_data_dir, mock_me):
+        terraform = CredentialType.defaults['terraform']()
+        hcl_config = '''
+        backend "s3" {
+            bucket = "s3_sample_bucket"
+            key    = "/tf_state/"
+            region = "us-east-1"
+        }
+        '''
+        credential = Credential(pk=1, credential_type=terraform, inputs={'configuration': hcl_config})
+        credential.inputs['configuration'] = encrypt_field(credential, 'configuration')
+        job.credentials.add(credential)
+
+        env = {}
+        safe_env = {}
+        credential.credential_type.inject_credential(credential, env, safe_env, [], private_data_dir)
+
+        local_path = to_host_path(env['TF_BACKEND_CONFIG_FILE'], private_data_dir)
+        config = open(local_path, 'r').read()
+        assert config == hcl_config
+
     def test_custom_environment_injectors_with_jinja_syntax_error(self, private_data_dir, mock_me):
         some_cloud = CredentialType(
             kind='cloud',


### PR DESCRIPTION
Add new functionality to AAP to support pushing TF BE configuration as secret to avoid pushing sensitive information from BE configuration (e.g. a user password)

Here is an example configuration

BE configuration to be added as `Terraform backend configuration` credential type into AAP
```
address = "https://localhost:8043/api/v2/state/1/"
skip_cert_verification = true
username = "ansible"
password = "test123!"
```

Example of terraform configuration `main.tf`

```
terraform {
  required_providers {
    ansible = {
      source  = "ansible/ansible"
    }
  }
  backend "http" {
  }
}

variable "host_name" {
  type = string
}

variable "host_ip" {
  type = string
}

variable "host_user" {
  type = string
}

resource "ansible_host" "my_ec2" {
  name   = var.host_name
  groups = ["fedora"]
  variables = {
    ansible_user  = var.host_user
    ansible_host  = var.host_ip
  }
}
```

AAP will inject a new environment variable named `TF_BACKEND_CONFIG_FILE`  with the location of the generated file containing BE configuration above into the Execution environment, this can be validated using the following playbook

```
---
- name: Terraform Backend configuration file
  hosts: localhost
  gather_facts: false

  tasks:
    - name: create simple terraform project
      cloud.terraform.terraform:
        force_init: true
        state: present
        project_path: '{{ tf_path }}'
        backend_config_files: "{{ lookup('env', 'TF_BACKEND_CONFIG_FILE') }}"
```